### PR TITLE
(v1) project_iam_policy: see restore_policy and complete_policy on plan

### DIFF
--- a/google/field_helpers.go
+++ b/google/field_helpers.go
@@ -210,7 +210,7 @@ func parseZonalFieldValue(resourceType, fieldValue, projectSchemaField, zoneSche
 	}, nil
 }
 
-func getProjectFromSchema(projectSchemaField string, d TerraformResourceData, config *Config) (string, error) {
+func getProjectFromSchema(projectSchemaField string, d TerraformResourceGetter, config *Config) (string, error) {
 	res, ok := d.GetOk(projectSchemaField)
 	if ok && projectSchemaField != "" {
 		return res.(string), nil

--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -65,7 +65,7 @@ func resourceGoogleProjectIamPolicy() *schema.Resource {
 func customDiffIamPolicy(d *schema.ResourceDiff, meta interface{}) error {
 	// Compute `complete_policy` and `restore_policy` fields at the plan phase
 	// as same logic as resourceGoogleProjectIamPolicyUpdate to see planned changes
-	log.Printf("[DEBUG]: Updating google_project_iam_policy")
+	log.Printf("[DEBUG]: Computing diff for google_project_iam_policy")
 	config := meta.(*Config)
 	pid, err := getProject(d, config)
 	if err != nil {
@@ -83,14 +83,14 @@ func customDiffIamPolicy(d *schema.ResourceDiff, meta interface{}) error {
 	// An authoritative policy is applied without regard for any existing IAM
 	// policy.
 	if v, ok := d.GetOk("authoritative"); ok && v.(bool) {
-		log.Printf("[DEBUG] Updating authoritative IAM policy for project %q", pid)
+		log.Printf("[DEBUG] Computing diff for authoritative IAM policy for project %q", pid)
 		err = d.SetNew("complete_policy", string(pBytes))
 		if err != nil {
-			return fmt.Errorf("Error setting project IAM policy: %v", err)
+			return fmt.Errorf("Error computing diff for project IAM policy: %v", err)
 		}
 		d.SetNew("restore_policy", "")
 	} else {
-		log.Printf("[DEBUG] Updating non-authoritative IAM policy for project %q", pid)
+		log.Printf("[DEBUG] Computing diff for non-authoritative IAM policy for project %q", pid)
 		// Get the previous policy from state
 		pp, err := getPrevResourceIamPolicy(d)
 		if err != nil {
@@ -125,7 +125,7 @@ func customDiffIamPolicy(d *schema.ResourceDiff, meta interface{}) error {
 		ep.Bindings = mb
 		epBytes, _ = json.Marshal(ep)
 		if err = d.SetNew("complete_policy", string(epBytes)); err != nil {
-			return fmt.Errorf("Error applying IAM policy to project: %v", err)
+			return fmt.Errorf("Error computing diff for IAM policy to project: %v", err)
 		}
 	}
 

--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -47,6 +47,11 @@ func resourceGoogleProjectIamPolicy() *schema.Resource {
 				Type:       schema.TypeString,
 				Computed:   true,
 			},
+			"complete_policy": &schema.Schema{
+				Deprecated: "This field will be removed alongside the authoritative field, since it will be equivalent to policy_data field.",
+				Type:       schema.TypeString,
+				Computed:   true,
+			},
 			"disable_project": &schema.Schema{
 				Deprecated: "This will be removed with the authoritative field. Use lifecycle.prevent_destroy instead.",
 				Type:       schema.TypeBool,
@@ -125,6 +130,11 @@ func resourceGoogleProjectIamPolicyRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
+	completePolicyBytes, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("Error marshaling IAM policy: %v", err)
+	}
+	d.Set("complete_policy", string(completePolicyBytes))
 
 	var bindings []*cloudresourcemanager.Binding
 	if v, ok := d.GetOk("restore_policy"); ok {

--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -84,7 +84,7 @@ func customDiffIamPolicy(d *schema.ResourceDiff, meta interface{}) error {
 	// policy.
 	if v, ok := d.GetOk("authoritative"); ok && v.(bool) {
 		log.Printf("[DEBUG] Updating authoritative IAM policy for project %q", pid)
-		err = d.SetNew("complete_policy", p)
+		err = d.SetNew("complete_policy", string(pBytes))
 		if err != nil {
 			return fmt.Errorf("Error setting project IAM policy: %v", err)
 		}
@@ -123,7 +123,8 @@ func customDiffIamPolicy(d *schema.ResourceDiff, meta interface{}) error {
 		// Merge the policies together
 		mb := mergeBindings(append(p.Bindings, rp.Bindings...))
 		ep.Bindings = mb
-		if err = d.SetNew("complete_policy", ep); err != nil {
+		epBytes, _ = json.Marshal(ep)
+		if err = d.SetNew("complete_policy", string(epBytes)); err != nil {
 			return fmt.Errorf("Error applying IAM policy to project: %v", err)
 		}
 	}

--- a/google/resource_google_project_iam_policy.go
+++ b/google/resource_google_project_iam_policy.go
@@ -312,7 +312,7 @@ func setProjectIamPolicy(policy *cloudresourcemanager.Policy, config *Config, pi
 }
 
 // Get a cloudresourcemanager.Policy from a schema.ResourceData
-func getResourceIamPolicy(d *schema.ResourceData) (*cloudresourcemanager.Policy, error) {
+func getResourceIamPolicy(d TerraformResourceGetter) (*cloudresourcemanager.Policy, error) {
 	ps := d.Get("policy_data").(string)
 	// The policy string is just a marshaled cloudresourcemanager.Policy.
 	policy := &cloudresourcemanager.Policy{}
@@ -324,7 +324,7 @@ func getResourceIamPolicy(d *schema.ResourceData) (*cloudresourcemanager.Policy,
 
 // Get the previous cloudresourcemanager.Policy from a schema.ResourceData if the
 // resource has changed
-func getPrevResourceIamPolicy(d *schema.ResourceData) (*cloudresourcemanager.Policy, error) {
+func getPrevResourceIamPolicy(d TerraformResourceGetter) (*cloudresourcemanager.Policy, error) {
 	var policy *cloudresourcemanager.Policy = &cloudresourcemanager.Policy{}
 	if d.HasChange("policy_data") {
 		v, _ := d.GetChange("policy_data")

--- a/google/utils.go
+++ b/google/utils.go
@@ -19,9 +19,19 @@ import (
 
 type TerraformResourceData interface {
 	HasChange(string) bool
+	GetChange(string) (interface{}, interface{})
+	Get(string) interface{}
 	GetOk(string) (interface{}, bool)
 	Set(string, interface{}) error
 	SetId(string)
+	Id() string
+}
+
+type TerraformResourceGetter interface {
+	HasChange(string) bool
+	GetChange(string) (interface{}, interface{})
+	Get(string) interface{}
+	GetOk(string) (interface{}, bool)
 	Id() string
 }
 
@@ -60,7 +70,7 @@ func getRegionFromInstanceState(is *terraform.InstanceState, config *Config) (st
 // getProject reads the "project" field from the given resource data and falls
 // back to the provider's value if not given. If the provider's value is not
 // given, an error is returned.
-func getProject(d TerraformResourceData, config *Config) (string, error) {
+func getProject(d TerraformResourceGetter, config *Config) (string, error) {
 	return getProjectFromSchema("project", d, config)
 }
 


### PR DESCRIPTION
## Summary

See https://github.com/terraform-providers/terraform-provider-google/issues/4263 for why we need this.

The diff includes:

- 98fb40f: Add `complete_policy` field
- 938ad0e: Compute `restore_policy` and `complete_policy` on plan

## Meaning of each fields

This resource has three fields to hold policy (including newly added `complete_policy`):

| Field name        | Type        | Meaning | 
|:------------------|:------------|:--------|
| `policy_data`     | Required    | The policy you specified |
| `restore_policy`  | Output only | The policy actually applied to the project, but you don't specified in the `policy_data` field |
| `complete_policy` | Output only | The entire, complete policy actually applied to the project | 

The following equation illustrates the relation between them:

```
complete_policy = policy_data + restore_policy
```

If you set `authoritative=true`, the `complete_policy` will be totally equal to the `policy_data`, which means you lose the policy bindings appears in the `restore_policy`.

## Note about `customDiffIamPolicy()`

This function compute `complete_policy` and `restore_policy` fields at the plan phase, so that you can see what policy is planned to be applied before actually applying it.

The logic is completely same as the one used for apply: `resourceGoogleProjectIamPolicyUpdate`. Here's the diff between `resourceGoogleProjectIamPolicyUpdate` and `customDiffIamPolicy`

```bash
diff -U1 \
  <(sed -En '/^func resourceGoogleProjectIamPolicyUpdate/,/^}/p' \
    google/resource_google_project_iam_policy.go) \
  <(sed -En '/^func customDiffIamPolicy/,/^}/p' \
    google/resource_google_project_iam_policy.go)
```

```diff
--- /dev/fd/63	2019-08-19 16:52:56.000000000 +0900
+++ /dev/fd/62	2019-08-19 16:52:56.000000000 +0900
@@ -1,3 +1,5 @@
-func resourceGoogleProjectIamPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[DEBUG]: Updating google_project_iam_policy")
+func customDiffIamPolicy(d *schema.ResourceDiff, meta interface{}) error {
+	// Compute `complete_policy` and `restore_policy` fields at the plan phase
+	// as same logic as resourceGoogleProjectIamPolicyUpdate to see planned changes
+	log.Printf("[DEBUG]: Computing diff for google_project_iam_policy")
 	config := meta.(*Config)
@@ -8,6 +10,2 @@
 
-	mutexKey := getProjectIamPolicyMutexKey(pid)
-	mutexKV.Lock(mutexKey)
-	defer mutexKV.Unlock(mutexKey)
-
 	// Get the policy in the template
@@ -23,10 +21,16 @@
 	if v, ok := d.GetOk("authoritative"); ok && v.(bool) {
-		log.Printf("[DEBUG] Updating authoritative IAM policy for project %q", pid)
-		err := setProjectIamPolicy(p, config, pid)
+		log.Printf("[DEBUG] Computing diff for authoritative IAM policy for project %q", pid)
+		newP := string(pBytes)
+		oldP, _ := d.GetChange("complete_policy")
+		if jsonPolicyDiffSuppress("", oldP.(string), newP, nil) {
+			err = d.Clear("complete_policy")
+		} else {
+			err = d.SetNew("complete_policy", newP)
+		}
 		if err != nil {
-			return fmt.Errorf("Error setting project IAM policy: %v", err)
+			return fmt.Errorf("Error computing diff for project IAM policy: %v", err)
 		}
-		d.Set("restore_policy", "")
+		d.SetNew("restore_policy", "")
 	} else {
-		log.Printf("[DEBUG] Updating non-authoritative IAM policy for project %q", pid)
+		log.Printf("[DEBUG] Computing diff for non-authoritative IAM policy for project %q", pid)
 		// Get the previous policy from state
@@ -58,3 +62,12 @@
 		}
-		d.Set("restore_policy", string(rps))
+		newRp := string(rps)
+		oldRp, _ := d.GetChange("restore_policy")
+		if jsonPolicyDiffSuppress("", oldRp.(string), newRp, nil) {
+			err = d.Clear("restore_policy")
+		} else {
+			err = d.SetNew("restore_policy", newRp)
+		}
+		if err != nil {
+			return fmt.Errorf("Error setting diff for restore_policy: %v", err)
+		}
 
@@ -63,4 +76,12 @@
 		ep.Bindings = mb
-		if err = setProjectIamPolicy(ep, config, pid); err != nil {
-			return fmt.Errorf("Error applying IAM policy to project: %v", err)
+		epBytes, _ = json.Marshal(ep)
+		newEp := string(epBytes)
+		oldEp, _ := d.GetChange("complete_policy")
+		if jsonPolicyDiffSuppress("", oldEp.(string), newEp, nil) {
+			err = d.Clear("complete_policy")
+		} else {
+			err = d.SetNew("complete_policy", newEp)
+		}
+		if err != nil {
+			return fmt.Errorf("Error computing diff for IAM policy to project: %v", err)
 		}
@@ -68,3 +89,3 @@
 
-	return resourceGoogleProjectIamPolicyRead(d, meta)
+	return nil
 }
```

### The base branch

The base branch is checked out from `v1.20.0` tag, which is the last release of v1.

```bash
git checkout v1.20.0
git checkout -b v1
```
https://github.com/terraform-providers/terraform-provider-google/compare/v1.20.0...tmshn:v1